### PR TITLE
Enable additional verbose logging flags for Arnold

### DIFF
--- a/ncj/3dsmax/scripts/3dsmax.ps1
+++ b/ncj/3dsmax/scripts/3dsmax.ps1
@@ -104,10 +104,12 @@ if ($renderer -eq "arnold")
     $pre_render_script_content += "-- Fail on arnold license error`r`n"
     $pre_render_script_content += "r.abort_on_license_fail = true`r`n"
     $pre_render_script_content += "r.verbosity_level = 4`r`n"
-    $pre_render_script_content += "renderMessageManager.LogFileON = true`r`n"
-    $pre_render_script_content += "renderMessageManager.ShowInfoMessage = true`r`n"
-    $pre_render_script_content += "renderMessageManager.ShowProgressMessage = true`r`n"
-    $pre_render_script_content += "renderMessageManager.LogDebugMessage = true`r`n"
+    
+    # Uncomment the below for full verbose logging from Arnold
+    #$pre_render_script_content += "renderMessageManager.LogFileON = true`r`n"
+    #$pre_render_script_content += "renderMessageManager.ShowInfoMessage = true`r`n"
+    #$pre_render_script_content += "renderMessageManager.ShowProgressMessage = true`r`n"
+    #$pre_render_script_content += "renderMessageManager.LogDebugMessage = true`r`n"
 }
 
 if ($renderer -like "vray")

--- a/ncj/3dsmax/scripts/3dsmax.ps1
+++ b/ncj/3dsmax/scripts/3dsmax.ps1
@@ -104,6 +104,10 @@ if ($renderer -eq "arnold")
     $pre_render_script_content += "-- Fail on arnold license error`r`n"
     $pre_render_script_content += "r.abort_on_license_fail = true`r`n"
     $pre_render_script_content += "r.verbosity_level = 4`r`n"
+    $pre_render_script_content += "renderMessageManager.LogFileON = true`r`n"
+    $pre_render_script_content += "renderMessageManager.ShowInfoMessage = true`r`n"
+    $pre_render_script_content += "renderMessageManager.ShowProgressMessage = true`r`n"
+    $pre_render_script_content += "renderMessageManager.LogDebugMessage = true`r`n"
 }
 
 if ($renderer -like "vray")

--- a/ncj/3dsmax/scripts/3dsmax.ps1
+++ b/ncj/3dsmax/scripts/3dsmax.ps1
@@ -104,12 +104,10 @@ if ($renderer -eq "arnold")
     $pre_render_script_content += "-- Fail on arnold license error`r`n"
     $pre_render_script_content += "r.abort_on_license_fail = true`r`n"
     $pre_render_script_content += "r.verbosity_level = 4`r`n"
-    
-    # Uncomment the below for full verbose logging from Arnold
-    #$pre_render_script_content += "renderMessageManager.LogFileON = true`r`n"
-    #$pre_render_script_content += "renderMessageManager.ShowInfoMessage = true`r`n"
-    #$pre_render_script_content += "renderMessageManager.ShowProgressMessage = true`r`n"
-    #$pre_render_script_content += "renderMessageManager.LogDebugMessage = true`r`n"
+    $pre_render_script_content += "renderMessageManager.LogFileON = true`r`n"
+    $pre_render_script_content += "renderMessageManager.ShowInfoMessage = true`r`n"
+    $pre_render_script_content += "renderMessageManager.ShowProgressMessage = true`r`n"
+    $pre_render_script_content += "renderMessageManager.LogDebugMessage = true`r`n"
 }
 
 if ($renderer -like "vray")


### PR DESCRIPTION
These enable logging of Arnold version and additional verbosity which may be helpful for debugging, and don't significantly increase the filesize of the max_frame.log, so I believe we should enable them by default