### PR TITLE
Adding support for being able to select a custom image to render on

### DIFF
--- a/runner/custom_template_factory.py
+++ b/runner/custom_template_factory.py
@@ -35,7 +35,28 @@ def set_template_pool_id(in_memory_json_object: str, pool_id: str):
             elif in_memory_json_object.get("parameters").get("poolId").get('value'):
                 in_memory_json_object["parameters"]["poolId"]["value"] = pool_id
 
-    
+
+def set_custom_image(in_memory_json_object: str, VM_image_URL: str, VM_image_type: str):
+    """
+    Sets what the custom image the tests are going to run on. 
+
+    :param in_memory_json_object: The json object that needs to be updated with a version and offer type for the images 
+    :type in_memory_json_object: str
+    :param VM_image_URL: The resource link to an image inside your image repo.
+    :type VM_image_URL: 'str'
+    :param VM_image_type: The custom image operating system type.
+    :type VM_image_URL: 'str'
+    """
+
+    if in_memory_json_object.get("variables").get("osType").get("imageReference") is not None:
+        del in_memory_json_object["variables"]["osType"]["imageReference"]["publisher"]
+        del in_memory_json_object["variables"]["osType"]["imageReference"]["offer"]
+        del in_memory_json_object["variables"]["osType"]["imageReference"]["sku"]
+        del in_memory_json_object["variables"]["osType"]["imageReference"]["version"]
+        in_memory_json_object["variables"]["osType"]["imageReference"]["virtualMachineImageId"] = VM_image_URL
+
+    # TODO For handling windows and centos the nodeAgentSKUId needs to be changed in the json send object
+    # The centos image hasn't been tested so I haven't written logic for handling the VM_image_type
 
 
 def set_parameter_name(in_memory_json_object: str, job_id: str):

--- a/runner/job_manager.py
+++ b/runner/job_manager.py
@@ -125,7 +125,7 @@ class JobManager(object):
                 utils.print_batch_exception(err)
 
     def create_pool(self, batch_service_client: batch.BatchExtensionsClient,
-                    image_references: 'List[utils.ImageReference]'):
+                    image_references: 'List[utils.ImageReference]', VM_image_URL=None, VM_OS_type=None):
         """
         Creates the Pool that will be submitted to the batch service.
 
@@ -133,6 +133,12 @@ class JobManager(object):
         :param batch_service_client: The batch client used for making batch operations
         :type image_references: List['utils.ImageReference`]
         :param image_references: A list of image references that job can run
+        :type VM_image_URL: str
+        :param VM_image_URL: The resource link to an image inside your image repo. If this is resource link is provided
+        the VMs will use the custom image you provided.
+        :type VM_OS_type: str
+        :param VM_OS_type: The custom image operating system type, this can be windows or centos. This is needed if you
+        want to use a custom image.
         """
 
         # load the template file
@@ -145,6 +151,8 @@ class JobManager(object):
         # Set rendering version
         ctm.set_image_reference(template, image_references)
         ctm.set_template_pool_id(template, self.pool_id)
+        if VM_image_URL is not None and VM_OS_type is not None:
+            ctm.set_custom_image(template, VM_image_URL, VM_OS_type)
 
         all_pools = [p.id for p in batch_service_client.pool.list()]
 


### PR DESCRIPTION
This adds the ability to run the templates on VMs created with a custom image. 
Centos is not supported yet but it will arrive soon. 

added two optional args on the command line VMImageURL and VMImageType.
VMImageURL is the resource URL to the custom image and the VMImageType is the OS type of the image. 