### PR TITLE
Removed ND_v2 VM sizes

### DIFF
--- a/data/vm-sizes-list.json
+++ b/data/vm-sizes-list.json
@@ -236,8 +236,6 @@
         "standard_nd12s",
         "standard_nd24s",
         "standard_nd24rs",
-        "standard_nd40s_v2",
-        "standard_nd40rs_v2",
         "standard_nc6s_v3",
         "standard_nc12s_v3",
         "standard_nc24s_v3",


### PR DESCRIPTION
These are hidden behind a feature flag that we currently don't read from the service. Removing them for now.