### PR TITLE
Add ND A100 v4-series

### DIFF
--- a/data/vm-sizes-list.json
+++ b/data/vm-sizes-list.json
@@ -16,7 +16,8 @@
         "gpu": [
             "^standard_n[0-9a-z]*$",
             "^standard_n[0-9a-z]*_[v2]*$",
-            "^standard_n[0-9a-z]*_[v3]*$"
+            "^standard_n[0-9a-z]*_[v3]*$",
+            "^standard_nd[0-9a-z]*asr_[v4]*$"
         ],
         "hpc": [
             "standard_a8_v2",

--- a/data/vm-sizes-list.json
+++ b/data/vm-sizes-list.json
@@ -7,17 +7,137 @@
             "^standard_f[0-9a-z]*_[v3]*$"
         ],
         "memory": [
-            "^standard_g[0-9a-z]*$",
-            "^standard_d[0-9a-z]*$",
-            "^standard_d[0-9a-z]*_[v2]*$",
-            "^standard_e[0-9]*a_[v4]*$",
-            "^standard_e[0-9]*as_[v4]*$"
+            "standard_d11_v2",
+            "standard_d12_v2",
+            "standard_d13_v2",
+            "standard_d14_v2",
+            "standard_d15_v2",
+
+            "standard_ds11_v2",
+            "standard_ds12_v2",
+            "standard_ds13_v2",
+            "standard_ds14_v2",
+            "standard_ds15_v2",
+
+            "standard_e2_v3",
+            "standard_e4_v3",
+            "standard_e8_v3",
+            "standard_e16_v3",
+            "standard_e32_v3",
+            "standard_e64_v3",
+
+            "standard_e2s_v3",
+            "standard_e4s_v3",
+            "standard_e8s_v3",
+            "standard_e16s_v3",
+            "standard_e32s_v3",
+            "standard_e48s_v3",
+            "standard_e64s_v3",
+
+            "standard_e2a_v4",
+            "standard_e4a_v4",
+            "standard_e8a_v4",
+            "standard_e16a_v4",
+            "standard_e32a_v4",
+            "standard_e48a_v4",
+            "standard_e64a_v4",
+            "standard_e96a_v4",
+
+            "standard_e2as_v4",
+            "standard_e4as_v4",
+            "standard_e8as_v4",
+            "standard_e16as_v4",
+            "standard_e32as_v4",
+            "standard_e48as_v4",
+            "standard_e64as_v4",
+            "standard_e96as_v4",
+
+            "standard_e2d_v4",
+            "standard_e4d_v4",
+            "standard_e8d_v4",
+            "standard_e16d_v4",
+            "standard_e32d_v4",
+            "standard_e48d_v4",
+            "standard_e64d_v4",
+
+            "standard_e2ds_v4",
+            "standard_e4ds_v4",
+            "standard_e8ds_v4",
+            "standard_e16ds_v4",
+            "standard_e32ds_v4",
+            "standard_e48ds_v4",
+            "standard_e64ds_v4",
+            "standard_e80ids_v4",
+
+            "standard_m8ms",
+            "standard_m16ms",
+            "standard_m32ms",
+            "standard_m32ls",
+            "standard_m32ts",
+            "standard_m64ls",
+            "standard_m64",
+            "standard_m64m",
+            "standard_m64s",
+            "standard_m64ms",
+            "standard_m128",
+            "standard_m128m",
+            "standard_m128ms",
+            "standard_m128s",
+
+            "standard_m208ms_v2",
+            "standard_m208s_v2",
+            "standard_m416ms_v2",
+            "standard_m416s_v2"
         ],
         "gpu": [
-            "^standard_n[0-9a-z]*$",
-            "^standard_n[0-9a-z]*_[v2]*$",
-            "^standard_n[0-9a-z]*_[v3]*$",
-            "^standard_nd[0-9a-z]*asr_[v4]*$"
+            "standard_nc6",
+            "standard_nc12",
+            "standard_nc24",
+            "standard_nc24r",
+
+            "standard_nc6_promo",
+            "standard_nc12_promo",
+            "standard_nc24_promo",
+            "standard_nc24r_promo",
+
+            "standard_nc6s_v2",
+            "standard_nc12s_v2",
+            "standard_nc24s_v2",
+            "standard_nc24rs_v2",
+
+            "standard_nc6s_v3",
+            "standard_nc12s_v3",
+            "standard_nc24s_v3",
+            "standard_nc24rs_v3",
+
+            "standard_nc4as_t4_v3",
+            "standard_nc8as_t4_v3",
+            "standard_nc16as_t4_v3",
+            "standard_nc64as_t4_v3",
+
+            "standard_nd6s",
+            "standard_nd12s",
+            "standard_nd24s",
+            "standard_nd24rs",
+
+            "standard_nd96asr_v4",
+
+            "standard_nv6",
+            "standard_nv12",
+            "standard_nv24",
+
+            "standard_nv6_promo",
+            "standard_nv12_promo",
+            "standard_nv24_promo",
+
+            "standard_nv12s_v3",
+            "standard_nv24s_v3",
+            "standard_nv48s_v3",
+
+            "standard_nv4as_v4",
+            "standard_nv8as_v4",
+            "standard_nv16as_v4",
+            "standard_nv32as_v4"
         ],
         "hpc": [
             "standard_a8_v2",
@@ -27,7 +147,14 @@
             "^standard_h[bc][0-9a-z]*$",
             "^standard_h[bc][0-9a-z]*_promo*$",
             "^standard_h[bc][0-9a-z]*_[v2]*$",
-            "^standard_h[bc][0-9a-z]*_[v2]*_promo*$"
+            "^standard_h[bc][0-9a-z]*_[v2]*_promo*$",
+            "standard_hb60rs",
+            "standard_hc44rs",
+            "standard_hb120rs_v3",
+            "standard_hb120_16rs_v3",
+            "standard_hb120_32rs_v3",
+            "standard_hb120_64rs_v3",
+            "standard_hb120_96rs_v3"
         ],
         "standard": [
             "^standard_a[0-9a-z]*$",


### PR DESCRIPTION
Added ND A100 v4 series to BE categories and parity with Portal's categories.